### PR TITLE
Use curl instead of wget to download

### DIFF
--- a/rem-setup.sh
+++ b/rem-setup.sh
@@ -110,7 +110,7 @@ su -c "mkdir -p $ROOT_DIR" $USR
 if [ ! -f "$NAME.sh" ]; then
     # Download shell script
     echo -ne $DL_SCRPT
-    su -c "wget -q https://raw.githubusercontent.com/TheAppgineer/$NAME/v1.x/$NAME.sh" $USR
+    su -c "curl -sSfLO 'https://raw.githubusercontent.com/TheAppgineer/$NAME/v1.x/$NAME.sh'" $USR
     if [ $? -gt 0 ]; then
         echo -e $FAIL
         exit 1


### PR DESCRIPTION
`curl` is probably a tiny bit more assured to be available than `wget`, and it executes a bit faster, at least on all Debian versions I tested. With the used flags, the behaviour of the previous `wget` call is maintained:
- `-s/--silence` mutes all output
- `-S/--show-error` shows error messages despite `-s/--silence` is used
- `-f/--fail` assures that 40x HTML documents, possibly returned by the webserver, are not downloaded but the response code printed as error message with `curl` returning an error exit code
- `-L/--location` follows redirects: Actually not required here, could be skipped?
- `-O/--remote-name` downloads the document into a name matching the name in the request URL

This is really just a minor suggestion. I just ran into a failure since I always use `curl` and have `wget` not installed on my testing VMs 😉.